### PR TITLE
Use SO_REUSEADDR socket option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ net2 = "0.2.17"
 sha1 = "0.2.0"
 
 [features]
-default = ["ssl", "reuseaddr"]
+default = ["ssl"]
 nightly = ["hyper/nightly"]
 ssl = ["openssl", "hyper/ssl"]
 reuseaddr = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "websocket-vi"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["cyderize <admin@cyderize.org>", "Vitaly \"_Vi\" Shukela <vi0oss@gmail.com>"]
 
 description = "A WebSocket (RFC6455) library for Rust (fork)."
@@ -29,6 +29,7 @@ net2 = "0.2.17"
 sha1 = "0.2.0"
 
 [features]
-default = ["ssl"]
+default = ["ssl", "reuseaddr"]
 nightly = ["hyper/nightly"]
 ssl = ["openssl", "hyper/ssl"]
+reuseaddr = []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rust-WebSocket provides a framework for dealing with WebSocket connections (both
 To add a library release version from [crates.io](https://crates.io/crates/websocket) to a Cargo project, add this to the 'dependencies' section of your Cargo.toml:
 
 ```INI
-websocket-vi = "~0.18.0"
+websocket-vi = "~0.18.1"
 ```
 
 And add ```extern crate websocket_vi;``` to your project.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,9 @@
 //! Contains the WebSocket client.
 
+#[cfg(not(feature="reuseaddr"))]
 use std::net::TcpStream;
+#[cfg(feature="reuseaddr")]
+use net2::TcpBuilder;
 use std::marker::PhantomData;
 use std::io::Result as IoResult;
 
@@ -93,9 +96,19 @@ impl Client<DataFrame, Sender<WebSocketStream>, Receiver<WebSocketStream>> {
 			return Err(::result::WebSocketError::SslFeatureNotEnabled);
 		}}
 
-		let connection = try!(TcpStream::connect(
-			(&host.hostname[..], host.port.unwrap_or(if secure { 443 } else { 80 }))
-		));
+		let connection = {
+			let address = (&host.hostname[..], host.port.unwrap_or(if secure { 443 } else { 80 }));
+			#[cfg(not(feature="reuseaddr"))]
+			{
+				try!(TcpStream::connect(address))
+			}
+			#[cfg(feature="reuseaddr")]
+			{
+				let tcp = try!(TcpBuilder::new_v4());
+				try!(try!(tcp.reuse_address(true)).only_v6(false));
+				try!(tcp.connect(address))
+			}
+		};
 
 		#[cfg(feature="ssl")]
 		let stream = if secure {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -105,7 +105,7 @@ impl Client<DataFrame, Sender<WebSocketStream>, Receiver<WebSocketStream>> {
 			#[cfg(feature="reuseaddr")]
 			{
 				let tcp = try!(TcpBuilder::new_v4());
-				try!(try!(tcp.reuse_address(true)).only_v6(false));
+				try!(tcp.reuse_address(true));
 				try!(tcp.connect(address))
 			}
 		};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ extern crate openssl;
 extern crate rand;
 extern crate byteorder;
 extern crate sha1;
+extern crate net2;
 
 #[macro_use]
 extern crate bitflags;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,8 @@
 //! Provides an implementation of a WebSocket server
 use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
 use std::net::Shutdown;
+#[cfg(feature="reuseaddr")]
+use net2::TcpBuilder;
 use std::io::{Read, Write};
 use std::io;
 pub use self::request::Request;
@@ -14,6 +16,9 @@ use openssl::ssl::{SslStream};
 
 pub mod request;
 pub mod response;
+
+#[cfg(feature="reuseaddr")]
+const SOMAXCONN: i32 = 128;
 
 /// Represents a WebSocket server which can work with either normal (non-secure) connections, or secure WebSocket connections.
 ///
@@ -82,25 +87,45 @@ pub mod response;
 /// # #[cfg(feature="ssl")] fn main() { ssltest::main() }
 /// # #[cfg(not(feature="ssl"))] fn main(){ println!("SSL server test ignored"); }
 /// ```
+
 pub struct Server<'a> {
 	inner: TcpListener,
 	context: Option<&'a SslContext>,
 }
 
 impl<'a> Server<'a> {
+	#[cfg(feature="reuseaddr")]
+	fn make_builder() -> io::Result<TcpBuilder> {
+		let tcp = try!(TcpBuilder::new_v4());
+		try!(try!(tcp.reuse_address(true)).only_v6(false));
+		Ok(tcp)
+	}
+
+	fn bind_generic<T: ToSocketAddrs>(addr: T, context: Option<&'a SslContext>) -> io::Result<Server<'a>> {
+		Ok(Server {
+			inner: {
+				#[cfg(not(feature="reuseaddr"))]
+				{
+					try!(TcpListener::bind(&addr))
+				}
+				#[cfg(feature="reuseaddr")]
+				{
+					let builder = try!(Self::make_builder());
+					try!(builder.bind(&addr));
+					try!(builder.listen(SOMAXCONN))
+				}
+			},
+			context: context,
+		})
+	}
+
 	/// Bind this Server to this socket
 	pub fn bind<T: ToSocketAddrs>(addr: T) -> io::Result<Server<'a>> {
-		Ok(Server {
-			inner: try!(TcpListener::bind(&addr)),
-			context: None,
-		})
+		Self::bind_generic(addr, None)
 	}
 	/// Bind this Server to this socket, utilising the given SslContext
 	pub fn bind_secure<T: ToSocketAddrs>(addr: T, context: &'a SslContext) -> io::Result<Server<'a>> {
-		Ok(Server {
-			inner: try!(TcpListener::bind(&addr)),
-			context: Some(context),
-		})
+		Self::bind_generic(addr, Some(context))
 	}
 	/// Get the socket address of this server
 	pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -94,13 +94,6 @@ pub struct Server<'a> {
 }
 
 impl<'a> Server<'a> {
-	#[cfg(feature="reuseaddr")]
-	fn make_builder() -> io::Result<TcpBuilder> {
-		let tcp = try!(TcpBuilder::new_v4());
-		try!(try!(tcp.reuse_address(true)).only_v6(false));
-		Ok(tcp)
-	}
-
 	fn bind_generic<T: ToSocketAddrs>(addr: T, context: Option<&'a SslContext>) -> io::Result<Server<'a>> {
 		Ok(Server {
 			inner: {
@@ -110,7 +103,8 @@ impl<'a> Server<'a> {
 				}
 				#[cfg(feature="reuseaddr")]
 				{
-					let builder = try!(Self::make_builder());
+					let builder = try!(TcpBuilder::new_v4());
+					try!(builder.reuse_address(true));
 					try!(builder.bind(&addr));
 					try!(builder.listen(SOMAXCONN))
 				}


### PR DESCRIPTION
Default feature `reuseaddr` was added. If it is enabled, a new socket will be created with `SO_REUSEADDR` option.